### PR TITLE
Remove depend tag.

### DIFF
--- a/docs/htufa/introduction.md
+++ b/docs/htufa/introduction.md
@@ -20,8 +20,4 @@ libs:
     - src: jojoe77777/FormAPI/libFormAPI
       version: ^1.3
 ```
-and then the .phars will have the virions injected in them.  
-You can also add this in your plugin.yml to avoid crashes: 
-```
-depend: FormAPI
-```
+and then the .phars will have the virions injected in them.


### PR DESCRIPTION
The comment here about using depend is completely irrelevant and wrong when only describing how to use FormAPI as a virion.